### PR TITLE
上传文件夹文件数量超过最大同时上传文件数导致路径错误

### DIFF
--- a/src/components/file/preview/AudioPlayer.vue
+++ b/src/components/file/preview/AudioPlayer.vue
@@ -4,7 +4,7 @@
 
 <script setup>
 import APlayer from "aplayer"; // 引入音乐插件
-import "APlayer/dist/APlayer.min.css";
+import "aplayer/dist/APlayer.min.css";
 
 import useFileDataStore from "~/stores/file-data";
 


### PR DESCRIPTION
问题描述： 上传文件夹是文件夹内文件数量超过最大同时上传文件数，会导致上传后的路径错误
复现步骤：
上传名为dist-4.0.10的文件夹
![image](https://user-images.githubusercontent.com/35186865/215723646-007a3213-56a8-4c78-b518-6876f2a46676.png)
![image](https://user-images.githubusercontent.com/35186865/215722555-00966740-815b-4d4e-8fcb-7b050894ace8.png)
进入dist-4.0.10的文件夹里面重复了dist-4.0.10文件夹
![image](https://user-images.githubusercontent.com/35186865/215722805-d33b2483-7827-4d67-8a62-ec85437db3c0.png)
实际上本地的目录结构为
![image](https://user-images.githubusercontent.com/35186865/215723260-b0afa4c5-fec0-46d9-ae02-6e8be8329c3f.png)

修复后：
![image](https://user-images.githubusercontent.com/35186865/215725284-07552a61-5318-488e-a0b2-6899083db82f.png)