### PR TITLE
Fix:修复站点设置页面检测管理员存储源始终为空问题

### DIFF
--- a/src/pages/admin/site-setting.vue
+++ b/src/pages/admin/site-setting.vue
@@ -178,7 +178,7 @@ const checkAdminStoragePermission = () => {
 			}).then(res => {
 				let data = res.data;
 				if (data.length > 0) {
-					let user = data[0];
+					let user = data[1];
 					if (user.userStorageSourceList?.length === 0) {
 						ElMessageBox.confirm(`检测到你有 ${storageSize} 个存储源，但没有给管理员分配任何存储源，是否前往配置？（不配置将无法访问存储源）`, "提示", {
 							confirmButtonText: "确定",


### PR DESCRIPTION
### 修复站点设置页面检测管理员存储源始终为空问题

**问题背景**：  
无论管理员有没有存储源权限，在站点设置页面都会弹出`没有给管理员分配任何存储源`的提示框。

**变更内容**：  
- 在 `site-setting.vue` 中将需要判断存储源个数的用户修正为管理员。